### PR TITLE
qp.cpp ibv_query_port fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Fig.3 - User-fair, Two 2-node jobs competing with a 1-node job
 Compile server and wrapper.so, <br>
 `git clone https://github.com/bbThemis/ThemisIO`<br>
 `cd ThemisIO`<br>
+`mkdir obj` <br>
 `make`<br>
 `cd src/client`<br>
 `./compile.sh`<br>

--- a/src/qp.cpp
+++ b/src/qp.cpp
@@ -1063,10 +1063,10 @@ void SERVER_QUEUEPAIR::Init_Server_IB_Env(int remote_buff_size)
 	
 //	struct ibv_device_attr device_attr;
 	
-//	if (!context_) {
-//		fprintf(stderr, "Error occured at %s:L%d. Failure: No HCA can use.\n", __FILE__, __LINE__);
-//		exit(1);
-//	}
+	if (!Found_IB) {
+		fprintf(stderr, "Error occured at %s:L%d. Failure: No HCA can use.\n", __FILE__, __LINE__);
+		exit(1);
+	}
 	
 //	ret = ibv_query_device(context_, &device_attr);
 //	printf("max_qp = %d max_qp_wr = %d\n", device_attr.max_qp, device_attr.max_qp_wr);

--- a/src/qp.cpp
+++ b/src/qp.cpp
@@ -1071,13 +1071,13 @@ void SERVER_QUEUEPAIR::Init_Server_IB_Env(int remote_buff_size)
 //	ret = ibv_query_device(context_, &device_attr);
 //	printf("max_qp = %d max_qp_wr = %d\n", device_attr.max_qp, device_attr.max_qp_wr);
 	
-	ret = ibv_query_port(context_, 1, &port_attr_);
+	// ret = ibv_query_port(context_, 1, &port_attr_);
 	
-	if (ret != 0 || port_attr_.lid == 0) {
-		// error handling
-		fprintf(stderr, "Error occured at %s:L%d. Failure: ibv_query_port.\n", __FILE__, __LINE__);
-		exit(1);
-	}
+	// if (ret != 0 || port_attr_.lid == 0) {
+	// 	// error handling
+	// 	fprintf(stderr, "Error occured at %s:L%d. Failure: ibv_query_port.\n", __FILE__, __LINE__);
+	// 	exit(1);
+	// }
 	
 	pd_ = ibv_alloc_pd(context_);
 	assert(pd_ != NULL);

--- a/src/qp.cpp
+++ b/src/qp.cpp
@@ -1043,18 +1043,21 @@ void SERVER_QUEUEPAIR::Init_Server_IB_Env(int remote_buff_size)
 	assert(dev_list_ != NULL);
 	
 	for (int i = 0; i < devices; i++) {
-		ibv_device* device = dev_list_[i];
-		
-		if (!device) {
-			continue;
-		}
-		
-		context_ = ibv_open_device(device);
-		
-		if (!context_) {
-			continue;
-		}
-	}
+        if (!dev_list_[i]) {
+            continue;
+        }
+        context_ = ibv_open_device(dev_list_[i]);
+        if (!context_)	continue;
+        
+        ret = ibv_query_port(context_, 1, &port_attr_);
+        if (ret != 0 || port_attr_.lid == 0) {
+            ibv_close_device(context_);
+            continue;
+        }
+
+        Found_IB = 1;
+        break;
+    }
 
 	assert(context_ != NULL);
 	

--- a/src/qp.cpp
+++ b/src/qp.cpp
@@ -1030,7 +1030,7 @@ done:   /* we get here if we got a signal like Ctrl-C */
 
 void SERVER_QUEUEPAIR::Init_Server_IB_Env(int remote_buff_size)
 {
-	int i, ret;
+	int i, ret, Found_IB=0;
 	int devices;
 	
 	dev_list_ = ibv_get_device_list(&devices);


### PR DESCRIPTION
In my attempts to build and use the ThemisIO implementation from the main branch, I ran into the "Failure: ibv_query_port" issue. I noticed a fix for it in client/qp_client.h so I used it in src/qp.cpp too.

I also updated the README